### PR TITLE
live stitching preview in the Params extension

### DIFF
--- a/embroider.py
+++ b/embroider.py
@@ -121,7 +121,7 @@ class EmbroideryElement(object):
 
         if param.endswith('_mm'):
             # print >> dbg, "get_float_param", param, value, "*", self.options.pixels_per_mm
-            value = value * self.options.pixels_per_mm
+            value = value * getattr(self.options, "pixels_per_mm", 10)
 
         return value
 
@@ -133,7 +133,7 @@ class EmbroideryElement(object):
             return default
 
         if param.endswith('_mm'):
-            value = int(value * self.options.pixels_per_mm)
+            value = int(value * getattr(self.options, "pixels_per_mm", 10))
 
         return value
 
@@ -207,7 +207,7 @@ class EmbroideryElement(object):
 
         path = deepcopy(path)
 
-        cspsubdiv(path, self.options.flat)
+        cspsubdiv(path, getattr(self.options, "flat", 0.1))
 
         flattened = []
 
@@ -500,7 +500,7 @@ class Fill(EmbroideryElement):
 
         # only stitch the first point if it's a reasonable distance away from the
         # last stitch
-        if not patch.stitches or (beg - patch.stitches[-1]).length() > 0.5 * self.options.pixels_per_mm:
+        if not patch.stitches or (beg - patch.stitches[-1]).length() > 0.5 * getattr(self.options, "pixels_per_mm", 10):
             patch.add_stitch(beg)
 
         first_stitch = self.adjust_stagger(beg, angle, row_spacing, max_stitch_length)
@@ -515,7 +515,7 @@ class Fill(EmbroideryElement):
             patch.add_stitch(beg + offset * row_direction)
             offset += max_stitch_length
 
-        if (end - patch.stitches[-1]).length() > 0.1 * self.options.pixels_per_mm:
+        if (end - patch.stitches[-1]).length() > 0.1 * getattr(self.options, "pixels_per_mm", 10):
             patch.add_stitch(end)
 
 
@@ -1000,7 +1000,7 @@ class AutoFill(Fill):
             patch.add_stitch(PyEmb.Point(*outline.interpolate(pos).coords[0]))
 
         end = PyEmb.Point(*end)
-        if (end - patch.stitches[-1]).length() > 0.1 * self.options.pixels_per_mm:
+        if (end - patch.stitches[-1]).length() > 0.1 * getattr(self.options, "pixels_per_mm", 10):
             patch.add_stitch(end)
 
         print >> dbg, "end connect_points"
@@ -1941,5 +1941,3 @@ if __name__ == '__main__':
         print >> dbg, traceback.format_exc()
 
     dbg.flush()
-
-dbg.close()

--- a/embroider_params.py
+++ b/embroider_params.py
@@ -403,9 +403,16 @@ class SettingsFrame(wx.Frame):
             try:
                 self.simulate_window = EmbroiderySimulator(None, -1, "Embroidery Simulator", simulator_pos, size=(300, 300), patches=patches, on_close=self.simulate_window_closed, target_duration=5)
             except:
-                with open('/tmp/params_debug.log', 'a') as log:
-                    print >> log, traceback.format_exc()
-                    log.flush()
+                error = traceback.format_exc()
+
+                try:
+                    # a window may have been created, so we need to destroy it
+                    # or the app will never exit
+                    wx.Window.FindWindowByName("Embroidery Simulator").Destroy()
+                except:
+                    pass
+
+                info_dialog(self, error, "Internal Error")
 
             self.simulate_window.Show()
             wx.CallLater(10, self.Raise)
@@ -731,7 +738,7 @@ def save_stderr():
 def restore_stderr():
     os.dup2(sys.stderr_dup, 2)
     sys.stderr_backup.write(sys.stderr.getvalue())
-    sys.sys.stderr = stderr_backup
+    sys.stderr = stderr_backup
 
 
 # end of class MyFrame

--- a/embroider_params.py
+++ b/embroider_params.py
@@ -388,7 +388,7 @@ class SettingsFrame(wx.Frame):
     def update_patches(self):
         patches = self.generate_patches()
 
-        if patches:
+        if patches and not self.simulate_refresh_needed.is_set():
             wx.CallAfter(self.refresh_simulator, patches)
 
     def refresh_simulator(self, patches):

--- a/embroider_params.py
+++ b/embroider_params.py
@@ -328,11 +328,13 @@ class SettingsFrame(wx.Frame):
         self.tabs = self.tabs_factory(self.notebook)
 
         for tab in self.tabs:
-            tab.on_change(self.params_changed)
+            tab.on_change(self.update_simulator)
 
         self.simulate_window = None
         self.simulate_thread = None
         self.simulate_refresh_needed = Event()
+
+        wx.CallLater(1000, self.update_simulator)
 
         self.presets_box = wx.StaticBox(self, wx.ID_ANY, label="Presets")
 
@@ -365,7 +367,7 @@ class SettingsFrame(wx.Frame):
         self.__do_layout()
         # end wxGlade
 
-    def params_changed(self, tab):
+    def update_simulator(self, tab=None):
         if self.simulate_window:
             self.simulate_window.stop()
             self.simulate_window.clear()
@@ -387,9 +389,9 @@ class SettingsFrame(wx.Frame):
         patches = self.generate_patches()
 
         if patches:
-            wx.CallAfter(self.update_simulator, patches)
+            wx.CallAfter(self.refresh_simulator, patches)
 
-    def update_simulator(self, patches):
+    def refresh_simulator(self, patches):
         if self.simulate_window:
             self.simulate_window.stop()
             self.simulate_window.load(patches=patches)

--- a/embroider_params.py
+++ b/embroider_params.py
@@ -401,7 +401,7 @@ class SettingsFrame(wx.Frame):
             simulator_pos.x += 5
 
             try:
-                self.simulate_window = EmbroiderySimulator(None, -1, "Embroidery Simulator", simulator_pos, size=(300, 300), patches=patches, on_close=self.simulate_window_closed, stitches_per_frame=10)
+                self.simulate_window = EmbroiderySimulator(None, -1, "Embroidery Simulator", simulator_pos, size=(300, 300), patches=patches, on_close=self.simulate_window_closed, target_duration=5)
             except:
                 with open('/tmp/params_debug.log', 'a') as log:
                     print >> log, traceback.format_exc()

--- a/embroider_params.py
+++ b/embroider_params.py
@@ -305,7 +305,7 @@ class SettingsFrame(wx.Frame):
     def __init__(self, *args, **kwargs):
         # begin wxGlade: MyFrame.__init__
         self.tabs_factory = kwargs.pop('tabs_factory', [])
-        wx.Frame.__init__(self, None, wx.ID_ANY, 
+        wx.Frame.__init__(self, None, wx.ID_ANY,
                           "Embroidery Params"
                           )
         self.notebook = wx.Notebook(self, wx.ID_ANY)
@@ -397,10 +397,10 @@ class SettingsFrame(wx.Frame):
 
 
     def _load_preset(self, preset_name):
-        preset = self.check_and_load_preset(preset_name)         
+        preset = self.check_and_load_preset(preset_name)
         if not preset:
             return
-        
+
         for tab in self.tabs:
             tab.load_preset(preset)
 
@@ -420,11 +420,11 @@ class SettingsFrame(wx.Frame):
         if not preset_name:
             return
 
-        preset = self.check_and_load_preset(preset_name)         
+        preset = self.check_and_load_preset(preset_name)
         if not preset:
             return
 
-        delete_preset(preset_name)        
+        delete_preset(preset_name)
         self.update_preset_list()
         self.preset_chooser.SetValue("")
 
@@ -521,7 +521,7 @@ class EmbroiderParams(inkex.Effect):
         else:
             getter = 'get_param'
 
-        values = filter(lambda item: item is not None, 
+        values = filter(lambda item: item is not None,
                         (getattr(node, getter)(param.name, param.default) for node in nodes))
 
         return values

--- a/embroider_simulate.py
+++ b/embroider_simulate.py
@@ -118,7 +118,7 @@ class EmbroiderySimulator(wx.Frame):
 
     def go(self):
         self.current_stitch = 0
-        self.timer = wx.PyTimer(self.draw_one_stitch)
+        self.timer = wx.PyTimer(self.draw_one_frame)
         self.timer.Start(self.frame_period)
 
     def clear(self):
@@ -149,7 +149,7 @@ class EmbroiderySimulator(wx.Frame):
         dc = wx.ClientDC(self)
         dc.DrawBitmap(self.buffer, 0, 0)
 
-    def draw_one_stitch(self):
+    def draw_one_frame(self):
         for i in xrange(self.stitches_per_frame):
             try:
                 ((x1, y1), (x2, y2)), color = self.stitches[self.current_stitch]

--- a/embroider_simulate.py
+++ b/embroider_simulate.py
@@ -41,8 +41,10 @@ class EmbroiderySimulator(wx.Frame):
 
     def load(self, stitch_file=None, patches=None):
         if stitch_file:
+            self.mirror = True
             self.segments = self._parse_stitch_file(stitch_file)
         elif patches:
+            self.mirror = False
             self.segments = self._patches_to_segments(patches)
         else:
             return
@@ -210,8 +212,10 @@ class EmbroiderySimulator(wx.Frame):
         for i in xrange(self.stitches_per_frame):
             try:
                 ((x1, y1), (x2, y2)), color = self.segments[self.current_stitch]
-                y1 = self.height - y1
-                y2 = self.height - y2
+
+                if self.mirror:
+                    y1 = self.height - y1
+                    y2 = self.height - y2
 
                 self.canvas.SetPen(color)
                 self.canvas.DrawLines(((x1, y1), (x2, y2)))

--- a/embroider_simulate.py
+++ b/embroider_simulate.py
@@ -84,6 +84,10 @@ class EmbroiderySimulator(wx.Frame):
                 self.timer.Stop()
             else:
                 self.timer.Start(self.frame_period)
+        elif keycode == ord("R"):
+            self.stop()
+            self.clear()
+            self.go()
 
         self.frame_period = max(1, self.frame_period)
         self.stitches_per_frame = max(self.stitches_per_frame, 1)
@@ -208,7 +212,10 @@ class EmbroiderySimulator(wx.Frame):
         self.clear()
 
         self.current_stitch = 0
-        self.timer = wx.PyTimer(self.draw_one_frame)
+
+        if not self.timer:
+            self.timer = wx.PyTimer(self.draw_one_frame)
+
         self.timer.Start(self.frame_period)
 
     def on_close(self, event):

--- a/embroider_simulate.py
+++ b/embroider_simulate.py
@@ -179,6 +179,8 @@ class EmbroiderySimulator(wx.Frame):
     def clear(self):
         self.dc.SetBackground(wx.Brush('white'))
         self.dc.Clear()
+        self.last_pos = None
+        self.Refresh()
 
     def on_size(self, e):
         # ensure that the whole canvas is visible

--- a/embroider_simulate.py
+++ b/embroider_simulate.py
@@ -14,6 +14,7 @@ class EmbroiderySimulator(wx.Frame):
         self.on_close_hook = kwargs.pop('on_close', None)
         self.frame_period = kwargs.pop('frame_period', 80)
         self.stitches_per_frame = kwargs.pop('stitches_per_frame', 1)
+        self.target_duration = kwargs.pop('target_duration', None)
 
         wx.Frame.__init__(self, *args, **kwargs)
 
@@ -21,6 +22,9 @@ class EmbroiderySimulator(wx.Frame):
         self.panel.SetFocus()
 
         self.load(stitch_file, patches)
+
+        if self.target_duration:
+            self.adjust_speed(self.target_duration)
 
         self.buffer = wx.Bitmap(self.width, self.height)
         self.dc = wx.MemoryDC()
@@ -50,6 +54,14 @@ class EmbroiderySimulator(wx.Frame):
             return
 
         self.width, self.height = self.get_dimensions()
+
+    def adjust_speed(self, duration):
+        self.frame_period = 1000 * float(duration) / len(self.segments)
+        self.stitches_per_frame = 1
+
+        while self.frame_period < 1.0:
+            self.frame_period *= 2
+            self.stitches_per_frame *= 2
 
     def on_key_down(self, event):
         keycode = event.GetKeyCode()

--- a/embroider_simulate.py
+++ b/embroider_simulate.py
@@ -177,7 +177,6 @@ class EmbroiderySimulator(wx.Frame):
             min_x = min(min_x, x)
             min_y = min(min_y, y)
 
-
         new_segments = []
 
         for segment in self.segments:

--- a/embroider_simulate.py
+++ b/embroider_simulate.py
@@ -53,6 +53,7 @@ class EmbroiderySimulator(wx.Frame):
         else:
             return
 
+        self.trim_margins()
         self.width, self.height = self.get_dimensions()
 
     def adjust_speed(self, duration):
@@ -159,15 +160,48 @@ class EmbroiderySimulator(wx.Frame):
 
         return segments
 
+    def all_coordinates(self):
+        for segment in self.segments:
+            start, end = segment[0]
+
+            yield start
+            yield end
+
+    def trim_margins(self):
+        """remove any unnecessary whitespace around the design"""
+
+        min_x = sys.maxint
+        min_y = sys.maxint
+
+        for x, y in self.all_coordinates():
+            min_x = min(min_x, x)
+            min_y = min(min_y, y)
+
+
+        new_segments = []
+
+        for segment in self.segments:
+            (start, end), color = segment
+
+            new_segment = (
+                           (
+                            (start[0] - min_x, start[1] - min_y),
+                            (end[0] - min_x, end[1] - min_y),
+                           ),
+                           color
+                          )
+
+            new_segments.append(new_segment)
+
+        self.segments = new_segments
+
     def get_dimensions(self):
         width = 0
         height = 0
 
-        for segment in self.segments:
-            (start_x, start_y), (end_x, end_y) = segment[0]
-
-            width = max(width, start_x, end_x)
-            height = max(height, start_y, end_y)
+        for x, y in self.all_coordinates():
+            width = max(width, x)
+            height = max(height, y)
 
         return width, height
 


### PR DESCRIPTION
When you open Params, a second window pops up that shows you what the stitching will look like.  It uses the same system as the Simulate extension, and it acts as if you've run Embroider with the same objects selected.

When you update parameters, the preview window redraws.  This lets you very quickly see the results of your changes as you make them.

My hope is that this may be a big step toward making inkscape-embroidery feel a lot more like a "real" embroidery design program.  It can also save the user a lot of time that would previously have been spent alternating between adjusting Params and running Embroider or Simulate.

What's still missing: as a user, I'd really like to be able to zoom in on the simulator window and pan it around.  I'm starting to hit the boundaries of my limited GUI programming abilities, though. 